### PR TITLE
Clarify license in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,12 +5,11 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "setuptools-gettext"
 maintainers = [{name = "Breezy Developers", email = "breezy-core@googlegroups.com"}]
-license = {text = "GPLv2 or later"}
 description = "Setuptools gettext extension plugin"
 keywords = ["distutils", "setuptools", "gettext"]
 classifiers = [
     "Topic :: Software Development :: Version Control",
-    "License :: OSI Approved :: Apache Software License",
+    "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.7",


### PR DESCRIPTION
Change the trove classifier for license to match the license given in the source file.

Also removing the 'license' key, since according to https://packaging.python.org/en/latest/specifications/core-metadata/#license that is only needed when there's no trove classifier matching the license.