### PR TITLE
Delay adding entry points to finalize_distribution_options

### DIFF
--- a/setuptools_gettext/__init__.py
+++ b/setuptools_gettext/__init__.py
@@ -23,9 +23,6 @@
 import os
 import re
 from distutils import log
-from distutils.command.build import build
-from distutils.command.clean import clean
-from distutils.command.install import install
 from distutils.core import Command
 from distutils.dep_util import newer
 from distutils.spawn import find_executable
@@ -237,9 +234,9 @@ def has_gettext(_c) -> bool:
 
 
 def pyprojecttoml_config(dist: Distribution) -> None:
-    pass
-
-
-build.sub_commands.append(('build_mo', has_gettext))
-clean.sub_commands.append(('clean_mo', has_gettext))
-install.sub_commands.append(('install_mo', has_gettext))
+    build = dist.get_command_class("build")
+    build.sub_commands.append(('build_mo', has_gettext))
+    clean = dist.get_command_class("clean")
+    clean.sub_commands.append(('clean_mo', has_gettext))
+    install = dist.get_command_class("install")
+    install.sub_commands.append(('install_mo', has_gettext))


### PR DESCRIPTION
Having distutils-extra installed will break running the `build_mo` step, because distutils-extra will override the `build` command after `setuptools_gettext` was imported.

See https://github.com/pypa/setuptools/issues/4040
Fixes https://github.com/breezy-team/setuptools-gettext/issues/13