### PR TITLE
don't hardcode source dir

### DIFF
--- a/setuptools_gettext/__init__.py
+++ b/setuptools_gettext/__init__.py
@@ -327,8 +327,8 @@ class update_pot(Command):
         self.spawn(args)
 
 
-def has_gettext(_c) -> bool:
-    return os.path.isdir(DEFAULT_SOURCE_DIR)
+def has_gettext(command) -> bool:
+    return os.path.isdir(command.distribution.gettext_source_dir)
 
 
 def pyprojecttoml_config(dist: Distribution) -> None:


### PR DESCRIPTION
Currently, when specifying the `source_dir` option for a directory other than 'po', the `build_mo` is not executed because the `has_gettext` method is always checking for the default source_dir and ignoring what is specified by the pyproject.toml.

In this change the `has_gettext` retrieves the source_dir from values in `distribution`, which already has fallback values defined by `load_pyproject_config`.