### PR TITLE
tests: use context managers for temporary directories

### DIFF
--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -1,6 +1,6 @@
 import os
 import shutil
-import tempfile
+from tempfile import TemporaryDirectory
 from unittest import SkipTest
 
 from setuptools import Distribution
@@ -14,75 +14,74 @@ from setuptools_gettext import (
 
 
 def test_example_build():
-    td = tempfile.mkdtemp()
-    shutil.copytree("example", td + "/example")
+    with TemporaryDirectory() as td:
+        shutil.copytree("example", td + "/example")
 
-    old_cwd = os.getcwd()
+        old_cwd = os.getcwd()
 
-    dist = Distribution()
+        dist = Distribution()
 
-    load_pyproject_config(dist, {})
+        load_pyproject_config(dist, {})
 
-    os.chdir(td + "/example")
-    try:
-        cmd = build_mo(dist)
-        cmd.initialize_options()
-        cmd.finalize_options()
-        cmd.run()
-    finally:
-        os.chdir(old_cwd)
+        os.chdir(td + "/example")
+        try:
+            cmd = build_mo(dist)
+            cmd.initialize_options()
+            cmd.finalize_options()
+            cmd.run()
+        finally:
+            os.chdir(old_cwd)
 
 
 def test_example_install():
-    td = tempfile.mkdtemp()
-    shutil.copytree("example", td + "/example")
-    root = tempfile.mkdtemp()
+    with TemporaryDirectory() as td, TemporaryDirectory() as root:
+        shutil.copytree("example", td + "/example")
 
-    dist = Distribution()
+        dist = Distribution()
 
-    load_pyproject_config(dist, {})
+        load_pyproject_config(dist, {})
 
-    old_cwd = os.getcwd()
+        old_cwd = os.getcwd()
 
-    os.chdir(td + "/example")
-    try:
-        cmd = install_mo(dist)
-        cmd.initialize_options()
-        cmd.root = root  # type: ignore
-        cmd.finalize_options()
-        cmd.run()
-    finally:
-        os.chdir(old_cwd)
+        os.chdir(td + "/example")
+        try:
+            cmd = install_mo(dist)
+            cmd.initialize_options()
+            cmd.root = root  # type: ignore
+            cmd.finalize_options()
+            cmd.run()
+        finally:
+            os.chdir(old_cwd)
 
 
 def test_update_pot():
     # Skip this test if xgettext is not available
     if shutil.which("xgettext") is None:
         raise SkipTest("xgettext not available")
-    td = tempfile.mkdtemp()
-    shutil.copytree("example", td + "/example")
-    p = os.path.join(td, "example", "hallowereld", "example.py")
-    with open(p, "w") as f:
-        f.write('# Use the "_" shorthand for gettext\n')
-        f.write("from gettext import gettext as _\n")
-        f.write('print(_("Hello Example"))')
+    with TemporaryDirectory() as td:
+        shutil.copytree("example", td + "/example")
+        p = os.path.join(td, "example", "hallowereld", "example.py")
+        with open(p, "w") as f:
+            f.write('# Use the "_" shorthand for gettext\n')
+            f.write("from gettext import gettext as _\n")
+            f.write('print(_("Hello Example"))')
 
-    dist = Distribution(
-        attrs={
-            "name": "hallowereld",
-        }
-    )
+        dist = Distribution(
+            attrs={
+                "name": "hallowereld",
+            }
+        )
 
-    load_pyproject_config(dist, {})
+        load_pyproject_config(dist, {})
 
-    old_cwd = os.getcwd()
-    os.chdir(os.path.join(td, "example"))
-    try:
-        cmd = update_pot(dist)
-        cmd.initialize_options()
-        cmd.finalize_options()
-        cmd.run()
-    finally:
-        os.chdir(old_cwd)
-    with open(os.path.join(td, "example", "po", "hallowereld.pot")) as f:
-        assert "Hello Example" in f.read()
+        old_cwd = os.getcwd()
+        os.chdir(os.path.join(td, "example"))
+        try:
+            cmd = update_pot(dist)
+            cmd.initialize_options()
+            cmd.finalize_options()
+            cmd.run()
+        finally:
+            os.chdir(old_cwd)
+        with open(os.path.join(td, "example", "po", "hallowereld.pot")) as f:
+            assert "Hello Example" in f.read()

--- a/tests/test_setuptools_gettext.py
+++ b/tests/test_setuptools_gettext.py
@@ -1,21 +1,21 @@
 import os
-import tempfile
+from tempfile import TemporaryDirectory
 
 from setuptools_gettext import gather_built_files, lang_from_dir, parse_lang
 
 
 def test_lang_from_dir():
-    td = tempfile.mkdtemp()
-    podir = os.path.join(td, "po")
-    os.mkdir(podir)
-    with open(os.path.join(podir, "de.po"), "w") as f:
-        f.write("foo")
-    with open(os.path.join(podir, "fr.po"), "w") as f:
-        f.write("foo")
-    with open(os.path.join(podir, "de_DE.po"), "w") as f:
-        f.write("foo")
+    with TemporaryDirectory() as td:
+        podir = os.path.join(td, "po")
+        os.mkdir(podir)
+        with open(os.path.join(podir, "de.po"), "w") as f:
+            f.write("foo")
+        with open(os.path.join(podir, "fr.po"), "w") as f:
+            f.write("foo")
+        with open(os.path.join(podir, "de_DE.po"), "w") as f:
+            f.write("foo")
 
-    assert set(lang_from_dir(podir)) == {"de", "de_DE", "fr"}
+        assert set(lang_from_dir(podir)) == {"de", "de_DE", "fr"}
 
 
 def test_parse_lang():
@@ -24,18 +24,18 @@ def test_parse_lang():
 
 
 def test_gather_built_files():
-    td = tempfile.mkdtemp()
-    builddir = os.path.join(td, "po")
-    os.mkdir(builddir)
-    dedir = os.path.join(builddir, "de")
-    os.mkdir(dedir)
-    de_lc_messages_dir = os.path.join(dedir, "LC_MESSAGES")
-    os.mkdir(de_lc_messages_dir)
-    with open(os.path.join(de_lc_messages_dir, "app.mo"), "w") as f:
-        f.write("foo")
-    with open(os.path.join(de_lc_messages_dir, "app2.mo"), "w") as f:
-        f.write("foo")
-    assert set(gather_built_files(builddir)) == {
-        os.path.join(de_lc_messages_dir, "app.mo"),
-        os.path.join(de_lc_messages_dir, "app2.mo"),
-    }
+    with TemporaryDirectory() as td:
+        builddir = os.path.join(td, "po")
+        os.mkdir(builddir)
+        dedir = os.path.join(builddir, "de")
+        os.mkdir(dedir)
+        de_lc_messages_dir = os.path.join(dedir, "LC_MESSAGES")
+        os.mkdir(de_lc_messages_dir)
+        with open(os.path.join(de_lc_messages_dir, "app.mo"), "w") as f:
+            f.write("foo")
+        with open(os.path.join(de_lc_messages_dir, "app2.mo"), "w") as f:
+            f.write("foo")
+        assert set(gather_built_files(builddir)) == {
+            os.path.join(de_lc_messages_dir, "app.mo"),
+            os.path.join(de_lc_messages_dir, "app2.mo"),
+        }


### PR DESCRIPTION
This makes sure that the temporary directories are removed after test execution.