### PR TITLE
Allow to configure compiler in pyproject.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build
 *~
 __pycache__
 *.egg-info
+uv.lock
+.coverage

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ requires = ["setuptools", "setuptools-gettext"]
 source_dir = "po"
 # directory in which the generated .mo files are placed when building
 build_dir = "breezy/locale"
+# compiler to use: "auto", "msgfmt", or "translate-toolkit"
+compiler = "auto"
 ```
 
 ## Compilation tool
@@ -31,9 +33,14 @@ build_dir = "breezy/locale"
 By default, either ``msgfmt`` or the `translate-toolkit` package is used to
 compile the .po files into .mo files - whichever is available.
 
+Set ``compiler = "msgfmt"`` or ``compiler = "translate-toolkit"`` in
+``[tool.setuptools-gettext]`` to force a compiler from ``pyproject.toml``.
+Use ``compiler = "auto"`` to keep the default automatic detection.
+
 The ``--msgfmt`` option can be used to force the use of ``msgfmt``, and the
 ``--translate-toolkit`` option can be used to force the use of the
-translate-toolkit.
+translate-toolkit. Command line options take precedence over the
+``pyproject.toml`` setting.
 
 At the moment, ``msgfmt`` is preferred. In the future, the translate-toolkit
 will become the default.

--- a/setuptools_gettext/__init__.py
+++ b/setuptools_gettext/__init__.py
@@ -34,6 +34,8 @@ __version__ = (0, 1, 17)
 DEFAULT_SOURCE_DIR = "po"
 DEFAULT_BUILD_DIR = "locale"
 DEFAULT_LANGUAGE = "en"
+DEFAULT_COMPILER = "auto"
+VALID_COMPILERS = ("auto", "msgfmt", "translate-toolkit")
 
 
 def has_translate_toolkit() -> bool:
@@ -108,7 +110,7 @@ class build_mo(Command):
         ("lang=", None, "Comma-separated list of languages to process"),
     ]
 
-    boolean_options = ["force"]
+    boolean_options = ["force", "translate-toolkit", "msgfmt"]
 
     def initialize_options(self):
         self.build_dir = None
@@ -130,6 +132,14 @@ class build_mo(Command):
                 getattr(self.distribution, "gettext_build_dir", None)
                 or DEFAULT_BUILD_DIR
             )
+        if self.msgfmt is None and self.translate_toolkit is None:
+            compiler = getattr(
+                self.distribution, "gettext_compiler", DEFAULT_COMPILER
+            )
+            if compiler == "msgfmt":
+                self.msgfmt = True
+            elif compiler == "translate-toolkit":
+                self.translate_toolkit = True
         if self.lang is None:
             self.lang = lang_from_dir(self.source_dir)
         else:
@@ -416,6 +426,26 @@ def load_pyproject_config(dist: Distribution, cfg) -> None:
     dist.gettext_default_language = (  # type: ignore
         cfg.get("default_language") or DEFAULT_LANGUAGE
     )
+    dist.gettext_compiler = _normalize_compiler(  # type: ignore
+        cfg.get("compiler", DEFAULT_COMPILER)
+    )
+
+
+def _normalize_compiler(compiler) -> str:
+    if compiler is None:
+        return DEFAULT_COMPILER
+    if not isinstance(compiler, str):
+        raise ValueError(
+            "Unsupported setuptools-gettext compiler "
+            f"{compiler!r}; expected one of: {', '.join(VALID_COMPILERS)}"
+        )
+    compiler = compiler.strip().lower()
+    if compiler not in VALID_COMPILERS:
+        raise ValueError(
+            "Unsupported setuptools-gettext compiler "
+            f"{compiler!r}; expected one of: {', '.join(VALID_COMPILERS)}"
+        )
+    return compiler
 
 
 def find_source_files(dirname: str = "") -> List[str]:

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -55,6 +55,97 @@ def test_example_install():
             os.chdir(old_cwd)
 
 
+def test_load_pyproject_config_default_compiler():
+    dist = Distribution()
+
+    load_pyproject_config(dist, {})
+
+    assert getattr(dist, "gettext_compiler") == "auto"
+
+
+@pytest.mark.parametrize("compiler", ["auto", "msgfmt", "translate-toolkit"])
+def test_load_pyproject_config_compiler(compiler):
+    dist = Distribution()
+
+    load_pyproject_config(dist, {"compiler": compiler})
+
+    assert getattr(dist, "gettext_compiler") == compiler
+
+
+def test_load_pyproject_config_rejects_invalid_compiler():
+    dist = Distribution()
+
+    with pytest.raises(ValueError, match="Unsupported setuptools-gettext"):
+        load_pyproject_config(dist, {"compiler": "invalid"})
+
+
+def test_build_mo_uses_msgfmt_compiler_from_config():
+    with TemporaryDirectory() as td:
+        source_dir = os.path.join(td, "po")
+        os.mkdir(source_dir)
+        with open(os.path.join(source_dir, "nl.po"), "w") as f:
+            f.write("")
+        dist = Distribution(attrs={"name": "example"})
+
+        load_pyproject_config(
+            dist, {"source_dir": source_dir, "compiler": "msgfmt"}
+        )
+        cmd = build_mo(dist)
+        cmd.initialize_options()
+        cmd.finalize_options()
+
+    assert cmd.msgfmt is True
+    assert cmd.translate_toolkit is None
+
+
+def test_build_mo_uses_translate_toolkit_compiler_from_config():
+    with TemporaryDirectory() as td:
+        source_dir = os.path.join(td, "po")
+        os.mkdir(source_dir)
+        with open(os.path.join(source_dir, "nl.po"), "w") as f:
+            f.write("")
+        dist = Distribution(attrs={"name": "example"})
+
+        load_pyproject_config(
+            dist, {"source_dir": source_dir, "compiler": "translate-toolkit"}
+        )
+        cmd = build_mo(dist)
+        cmd.initialize_options()
+        cmd.finalize_options()
+
+    assert cmd.msgfmt is None
+    assert cmd.translate_toolkit is True
+
+
+@pytest.mark.parametrize(
+    ("compiler", "flag", "expected_msgfmt", "expected_translate_toolkit"),
+    [
+        ("translate-toolkit", "msgfmt", True, None),
+        ("msgfmt", "translate_toolkit", None, True),
+    ],
+)
+def test_build_mo_cli_compiler_flags_override_config(
+    compiler, flag, expected_msgfmt, expected_translate_toolkit
+):
+    with TemporaryDirectory() as td:
+        source_dir = os.path.join(td, "po")
+        os.mkdir(source_dir)
+        with open(os.path.join(source_dir, "nl.po"), "w") as f:
+            f.write("")
+        dist = Distribution(attrs={"name": "example"})
+
+        load_pyproject_config(
+            dist, {"source_dir": source_dir, "compiler": compiler}
+        )
+        cmd = build_mo(dist)
+        cmd.initialize_options()
+        setattr(cmd, flag, True)
+        cmd.finalize_options()
+
+    assert cmd.msgfmt is expected_msgfmt
+    assert cmd.translate_toolkit is expected_translate_toolkit
+
+
 def test_find_source_files_example():
     found = find_source_files("example")
     rel = sorted(os.path.relpath(p, "example") for p in found)


### PR DESCRIPTION
This allows standalone build to be reproducible by skipping the automatic detection.