### PR TITLE
Add support for locale/<code>/LC_MESSAGES/<domain>.po

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,10 @@ setup.py as well as hooking those into standard commands.
 ## Usage
 
 By default, setuptools_gettext compiles and installs mo files when there is a
-`po` directory present that contains ``.po`` files.
+`po` directory present that contains ``.po`` files. It also supports the
+standard gettext layout with ``locale/*/LC_MESSAGES/*.po`` files. If ``po`` is
+absent and a top-level ``locale`` directory contains standard gettext catalogs,
+that directory is used automatically.
 
 The .mo files are installed adjacent to your package as package data in a subdirectory called ``locale``.
 
@@ -27,6 +30,20 @@ build_dir = "breezy/locale"
 # compiler to use: "auto", "msgfmt", or "translate-toolkit"
 compiler = "auto"
 ```
+
+For standard gettext layouts, point both directories at the locale tree:
+
+```toml
+[tool.setuptools-gettext]
+source_dir = "breezy/locale"
+build_dir = "breezy/locale"
+```
+
+Flat ``po/de.po`` files compile to
+``<build_dir>/de/LC_MESSAGES/<project-name>.mo`` by default. Standard
+``locale/de/LC_MESSAGES/django.po`` files compile to
+``<build_dir>/de/LC_MESSAGES/django.mo`` by default. Passing
+``--output-base`` overrides the output name for both layouts.
 
 ## Compilation tool
 

--- a/setuptools_gettext/__init__.py
+++ b/setuptools_gettext/__init__.py
@@ -22,13 +22,22 @@
 
 import logging
 import os
-import re
 import sys
-from typing import List, Optional, Tuple
+from typing import Dict, List, Optional, Tuple
 
 from setuptools import Command
 from setuptools.dist import Distribution
+from setuptools.errors import OptionError
 from setuptools.modified import newer
+
+from .catalog import (
+    LC_MESSAGES,
+    Catalog,
+    discover_catalogs,
+    has_standard_catalogs,
+    mo_basename,
+    parse_lang,
+)
 
 __version__ = (0, 1, 17)
 DEFAULT_SOURCE_DIR = "po"
@@ -50,18 +59,27 @@ def has_msgfmt() -> bool:
     return find_executable("msgfmt") is not None
 
 
-def lang_from_dir(source_dir: os.PathLike) -> List[str]:
-    re_po = re.compile(r"^([a-zA-Z_]+)\.po$")
-    lang = []
-    for i in os.listdir(source_dir):
-        mo = re_po.match(i)
-        if mo:
-            lang.append(mo.group(1))
-    return lang
+def _detect_default_source_dir(dirname: str = "") -> str:
+    po_dir = os.path.join(dirname, DEFAULT_SOURCE_DIR)
+    if os.path.isdir(po_dir):
+        return DEFAULT_SOURCE_DIR
+
+    locale_dir = os.path.join(dirname, DEFAULT_BUILD_DIR)
+    if os.path.isdir(locale_dir) and has_standard_catalogs(locale_dir):
+        return DEFAULT_BUILD_DIR
+
+    return DEFAULT_SOURCE_DIR
 
 
-def parse_lang(lang: str) -> List[str]:
-    return [i.strip() for i in lang.split(",") if i.strip()]
+def _resolve_source_dir(dist: Distribution) -> str:
+    if getattr(dist, "gettext_source_dir_configured", False):
+        return dist.gettext_source_dir  # type: ignore
+
+    source_dir = dist.gettext_source_dir  # type: ignore
+    if source_dir == DEFAULT_SOURCE_DIR and not os.path.isdir(source_dir):
+        source_dir = _detect_default_source_dir()
+        dist.gettext_source_dir = source_dir  # type: ignore
+    return source_dir
 
 
 # Imported from distutils.util in Python 3.11:
@@ -115,18 +133,21 @@ class build_mo(Command):
     def initialize_options(self):
         self.build_dir = None
         self.output_base = None
+        self.output_base_explicit = False
         self.force = None
         self.msgfmt = None
         self.translate_toolkit = None
         self.lang = None
+        self.catalogs = []
         self.outfiles = []
 
     def finalize_options(self):
         self.set_undefined_options("build", ("force", "force"))
         self.prj_name = self.distribution.get_name()
+        self.output_base_explicit = bool(self.output_base)
         if not self.output_base:
             self.output_base = self.prj_name or "messages"
-        self.source_dir = self.distribution.gettext_source_dir  # type: ignore
+        self.source_dir = _resolve_source_dir(self.distribution)
         if self.build_dir is None:
             self.build_dir = (
                 getattr(self.distribution, "gettext_build_dir", None)
@@ -141,22 +162,44 @@ class build_mo(Command):
             elif compiler == "translate-toolkit":
                 self.translate_toolkit = True
         if self.lang is None:
-            self.lang = lang_from_dir(self.source_dir)
+            self.catalogs = discover_catalogs(self.source_dir)
         else:
-            self.lang = parse_lang(self.lang)
+            self.catalogs = discover_catalogs(
+                self.source_dir, parse_lang(self.lang)
+            )
+        self.lang = sorted({catalog.lang for catalog in self.catalogs})
+        self._check_duplicate_outputs()
 
     def get_inputs(self):
-        inputs = []
-        for lang in self.lang:
-            po = os.path.join(self.source_dir, lang + ".po")
-            if not os.path.isfile(po):
-                po = os.path.join(self.source_dir, lang + ".po")
-            inputs.append(po)
-        return inputs
+        return [catalog.po for catalog in self.catalogs]
+
+    def _mo_path(self, catalog: Catalog) -> str:
+        domain = catalog.domain
+        if catalog.uses_output_base or self.output_base_explicit:
+            assert self.output_base is not None
+            domain = self.output_base
+        assert self.build_dir is not None
+        return os.path.join(
+            self.build_dir,
+            catalog.lang,
+            LC_MESSAGES,
+            mo_basename(domain),
+        )
+
+    def _check_duplicate_outputs(self) -> None:
+        targets: Dict[str, str] = {}
+        for catalog in self.catalogs:
+            mo = self._mo_path(catalog)
+            if mo in targets:
+                raise OptionError(
+                    "Multiple gettext catalogs would compile to "
+                    f"{mo}: {targets[mo]} and {catalog.po}"
+                )
+            targets[mo] = catalog.po
 
     def run(self):
         """Run msgfmt for each language."""
-        if not self.lang:
+        if not self.catalogs:
             return
 
         if self.msgfmt and self.translate_toolkit:
@@ -183,7 +226,10 @@ class build_mo(Command):
 
         default_lang = self.distribution.gettext_default_language
 
-        if default_lang in self.lang:
+        if any(
+            catalog.lang == default_lang and catalog.uses_output_base
+            for catalog in self.catalogs
+        ):
             if find_executable("msginit") is None:
                 logging.warning("GNU gettext msginit utility not found!")
                 logging.warning("Skip creating English PO file.")
@@ -204,20 +250,13 @@ class build_mo(Command):
                     ]
                 )
 
-        basename = self.output_base
-        if not basename.endswith(".mo"):
-            basename += ".mo"
-
-        for lang in self.lang:
-            po = os.path.join(self.source_dir, lang + ".po")
-            if not os.path.isfile(po):
-                po = os.path.join(self.source_dir, lang + ".po")
-            dir_ = os.path.join(self.build_dir, lang, "LC_MESSAGES")
+        for catalog in self.catalogs:
+            dir_ = os.path.join(self.build_dir, catalog.lang, LC_MESSAGES)
             self.mkpath(dir_)
-            mo = os.path.join(dir_, basename)
-            if self.force or newer(po, mo):
-                logging.info(f"Compile: {po} -> {mo}")
-                self.compile_mo(po, mo)
+            mo = self._mo_path(catalog)
+            if self.force or newer(catalog.po, mo):
+                logging.info(f"Compile: {catalog.po} -> {mo}")
+                self.compile_mo(catalog.po, mo)
                 self.outfiles.append(mo)
 
     def compile_mo(self, po: str, mo: str):
@@ -390,7 +429,8 @@ class update_pot(Command):
 
 
 def has_gettext(command) -> bool:
-    return os.path.isdir(command.distribution.gettext_source_dir)
+    source_dir = _resolve_source_dir(command.distribution)
+    return os.path.isdir(source_dir)
 
 
 def _load_pyproject_toml(path: str = "pyproject.toml") -> dict:
@@ -417,8 +457,9 @@ def pyprojecttoml_config(dist: Distribution) -> None:
 
 
 def load_pyproject_config(dist: Distribution, cfg) -> None:
+    dist.gettext_source_dir_configured = bool(cfg.get("source_dir"))  # type: ignore
     dist.gettext_source_dir = (  # type: ignore
-        cfg.get("source_dir") or DEFAULT_SOURCE_DIR
+        cfg.get("source_dir") or _detect_default_source_dir()
     )
     dist.gettext_build_dir = (  # type: ignore
         cfg.get("build_dir") or DEFAULT_BUILD_DIR
@@ -460,7 +501,7 @@ def find_source_files(dirname: str = "") -> List[str]:
         else "pyproject.toml"
     )
     cfg = _load_pyproject_toml(pyproject)
-    source_dir = cfg.get("source_dir") or DEFAULT_SOURCE_DIR
+    source_dir = cfg.get("source_dir") or _detect_default_source_dir(dirname)
 
     source_dir_path = (
         os.path.join(dirname, source_dir) if dirname else source_dir

--- a/setuptools_gettext/catalog.py
+++ b/setuptools_gettext/catalog.py
@@ -1,0 +1,136 @@
+#
+# Copyright (C) 2007, 2009, 2011 Canonical Ltd.
+# Copyright (C) 2022-2023 Jelmer Vernooĳ <jelmer@jelmer.uk>
+# Copyright (C) 2026 Michal Čihař <michal@weblate.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+
+"""Gettext catalog discovery helpers."""
+
+import os
+from dataclasses import dataclass
+from glob import glob
+from typing import List, Optional
+
+LC_MESSAGES = "LC_MESSAGES"
+
+
+@dataclass(frozen=True)
+class Catalog:
+    lang: str
+    domain: str
+    po: str
+    uses_output_base: bool
+
+
+def lang_from_dir(source_dir: os.PathLike) -> List[str]:
+    lang: List[str] = []
+    if not os.path.isdir(source_dir):
+        return lang
+    for i in os.listdir(source_dir):
+        if i.endswith(".po") and not i.startswith("."):
+            lang.append(i[:-3])
+    return lang
+
+
+def parse_lang(lang: str) -> List[str]:
+    return [i.strip() for i in lang.split(",") if i.strip()]
+
+
+def _flat_catalogs_from_dir(source_dir: os.PathLike) -> List[Catalog]:
+    return [
+        Catalog(
+            lang=lang,
+            domain=lang,
+            po=os.path.join(source_dir, f"{lang}.po"),
+            uses_output_base=True,
+        )
+        for lang in lang_from_dir(source_dir)
+    ]
+
+
+def _standard_catalogs_from_dir(source_dir: os.PathLike) -> List[Catalog]:
+    catalogs = []
+    pattern = os.path.join(source_dir, "*", LC_MESSAGES, "*.po")
+    for po in glob(pattern):
+        lang = os.path.basename(os.path.dirname(os.path.dirname(po)))
+        domain = os.path.splitext(os.path.basename(po))[0]
+        catalogs.append(
+            Catalog(
+                lang=lang,
+                domain=domain,
+                po=po,
+                uses_output_base=False,
+            )
+        )
+    return catalogs
+
+
+def discover_catalogs(
+    source_dir: os.PathLike, lang: Optional[List[str]] = None
+) -> List[Catalog]:
+    if lang is None:
+        catalogs = _flat_catalogs_from_dir(source_dir)
+        catalogs.extend(_standard_catalogs_from_dir(source_dir))
+        return sorted(catalogs, key=lambda catalog: catalog.po)
+
+    catalogs = []
+    for language in lang:
+        found = False
+        flat_po = os.path.join(source_dir, f"{language}.po")
+        if os.path.isfile(flat_po):
+            found = True
+            catalogs.append(
+                Catalog(
+                    lang=language,
+                    domain=language,
+                    po=flat_po,
+                    uses_output_base=True,
+                )
+            )
+
+        pattern = os.path.join(source_dir, language, LC_MESSAGES, "*.po")
+        for po in sorted(glob(pattern)):
+            found = True
+            catalogs.append(
+                Catalog(
+                    lang=language,
+                    domain=os.path.splitext(os.path.basename(po))[0],
+                    po=po,
+                    uses_output_base=False,
+                )
+            )
+
+        if not found:
+            catalogs.append(
+                Catalog(
+                    lang=language,
+                    domain=language,
+                    po=flat_po,
+                    uses_output_base=True,
+                )
+            )
+    return catalogs
+
+
+def has_standard_catalogs(source_dir: str) -> bool:
+    pattern = os.path.join(source_dir, "*", LC_MESSAGES, "*.po")
+    return bool(glob(pattern))
+
+
+def mo_basename(name: str) -> str:
+    if name.endswith(".mo"):
+        return name
+    return f"{name}.mo"

--- a/tests/test_setuptools_gettext.py
+++ b/tests/test_setuptools_gettext.py
@@ -1,7 +1,26 @@
 import os
 from tempfile import TemporaryDirectory
 
-from setuptools_gettext import gather_built_files, lang_from_dir, parse_lang
+import pytest
+from setuptools import Distribution
+from setuptools.errors import OptionError
+
+import setuptools_gettext
+from setuptools_gettext import (
+    build_mo,
+    discover_catalogs,
+    find_source_files,
+    gather_built_files,
+    load_pyproject_config,
+    parse_lang,
+)
+from setuptools_gettext.catalog import lang_from_dir
+
+
+def write_file(path):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w") as f:
+        f.write("foo")
 
 
 def test_lang_from_dir():
@@ -14,8 +33,10 @@ def test_lang_from_dir():
             f.write("foo")
         with open(os.path.join(podir, "de_DE.po"), "w") as f:
             f.write("foo")
+        with open(os.path.join(podir, "pt-BR.po"), "w") as f:
+            f.write("foo")
 
-        assert set(lang_from_dir(podir)) == {"de", "de_DE", "fr"}
+        assert set(lang_from_dir(podir)) == {"de", "de_DE", "fr", "pt-BR"}
 
 
 def test_parse_lang():
@@ -39,3 +60,182 @@ def test_gather_built_files():
             os.path.join(de_lc_messages_dir, "app.mo"),
             os.path.join(de_lc_messages_dir, "app2.mo"),
         }
+
+
+def test_discover_catalogs_standard_layout():
+    with TemporaryDirectory() as td:
+        locale = os.path.join(td, "locale")
+        po = os.path.join(locale, "pt-BR", "LC_MESSAGES", "django.po")
+        write_file(po)
+
+        catalogs = discover_catalogs(locale)
+
+        assert catalogs[0].lang == "pt-BR"
+        assert catalogs[0].domain == "django"
+        assert catalogs[0].po == po
+        assert not catalogs[0].uses_output_base
+
+
+def run_build(cmd, monkeypatch):
+    compiled = []
+
+    def compile_mo(po, mo) -> None:
+        compiled.append((po, mo))
+        write_file(mo)
+
+    monkeypatch.setattr(setuptools_gettext, "has_msgfmt", lambda: True)
+    cmd.compile_mo = compile_mo
+    cmd.run()
+    return compiled
+
+
+def test_build_standard_layout_uses_po_filename_domain(monkeypatch):
+    with TemporaryDirectory() as td:
+        locale = os.path.join(td, "locale")
+        po = os.path.join(locale, "de", "LC_MESSAGES", "django.po")
+        write_file(po)
+        build_dir = os.path.join(td, "build")
+        dist = Distribution(attrs={"name": "demo"})
+        load_pyproject_config(
+            dist, {"source_dir": locale, "build_dir": build_dir}
+        )
+        cmd = build_mo(dist)
+        cmd.initialize_options()
+        cmd.finalize_options()
+
+        compiled = run_build(cmd, monkeypatch)
+
+        mo = os.path.join(build_dir, "de", "LC_MESSAGES", "django.mo")
+        assert compiled == [(po, mo)]
+        assert cmd.get_outputs() == [mo]
+
+
+def test_build_standard_layout_multiple_domains(monkeypatch):
+    with TemporaryDirectory() as td:
+        locale = os.path.join(td, "locale")
+        django_po = os.path.join(locale, "de", "LC_MESSAGES", "django.po")
+        djangojs_po = os.path.join(locale, "de", "LC_MESSAGES", "djangojs.po")
+        write_file(django_po)
+        write_file(djangojs_po)
+        build_dir = os.path.join(td, "build")
+        dist = Distribution(attrs={"name": "demo"})
+        load_pyproject_config(
+            dist, {"source_dir": locale, "build_dir": build_dir}
+        )
+        cmd = build_mo(dist)
+        cmd.initialize_options()
+        cmd.finalize_options()
+
+        compiled = set(run_build(cmd, monkeypatch))
+
+        assert compiled == {
+            (
+                django_po,
+                os.path.join(build_dir, "de", "LC_MESSAGES", "django.mo"),
+            ),
+            (
+                djangojs_po,
+                os.path.join(build_dir, "de", "LC_MESSAGES", "djangojs.mo"),
+            ),
+        }
+
+
+def test_build_standard_layout_output_base_overrides_domain(monkeypatch):
+    with TemporaryDirectory() as td:
+        locale = os.path.join(td, "locale")
+        po = os.path.join(locale, "de", "LC_MESSAGES", "django.po")
+        write_file(po)
+        build_dir = os.path.join(td, "build")
+        dist = Distribution(attrs={"name": "demo"})
+        load_pyproject_config(
+            dist, {"source_dir": locale, "build_dir": build_dir}
+        )
+        cmd = build_mo(dist)
+        cmd.initialize_options()
+        cmd.output_base = "custom"
+        cmd.finalize_options()
+
+        compiled = run_build(cmd, monkeypatch)
+
+        mo = os.path.join(build_dir, "de", "LC_MESSAGES", "custom.mo")
+        assert compiled == [(po, mo)]
+        assert cmd.get_outputs() == [mo]
+
+
+def test_build_mixed_layouts_without_output_collision(monkeypatch):
+    with TemporaryDirectory() as td:
+        source = os.path.join(td, "po")
+        flat_po = os.path.join(source, "de.po")
+        standard_po = os.path.join(source, "de", "LC_MESSAGES", "django.po")
+        write_file(flat_po)
+        write_file(standard_po)
+        build_dir = os.path.join(td, "build")
+        dist = Distribution(attrs={"name": "demo"})
+        load_pyproject_config(
+            dist, {"source_dir": source, "build_dir": build_dir}
+        )
+        cmd = build_mo(dist)
+        cmd.initialize_options()
+        cmd.finalize_options()
+
+        compiled = set(run_build(cmd, monkeypatch))
+
+        assert compiled == {
+            (
+                flat_po,
+                os.path.join(build_dir, "de", "LC_MESSAGES", "demo.mo"),
+            ),
+            (
+                standard_po,
+                os.path.join(build_dir, "de", "LC_MESSAGES", "django.mo"),
+            ),
+        }
+
+
+def test_duplicate_output_paths_are_rejected():
+    with TemporaryDirectory() as td:
+        locale = os.path.join(td, "locale")
+        write_file(os.path.join(locale, "de", "LC_MESSAGES", "django.po"))
+        write_file(os.path.join(locale, "de", "LC_MESSAGES", "app.po"))
+        dist = Distribution(attrs={"name": "demo"})
+        build_dir = os.path.join(td, "build")
+        load_pyproject_config(
+            dist, {"source_dir": locale, "build_dir": build_dir}
+        )
+        cmd = build_mo(dist)
+        cmd.initialize_options()
+        cmd.output_base = "custom"
+
+        with pytest.raises(OptionError, match="Multiple gettext catalogs"):
+            cmd.finalize_options()
+
+
+def test_load_pyproject_config_auto_detects_locale_without_po():
+    with TemporaryDirectory() as td:
+        write_file(
+            os.path.join(td, "locale", "de", "LC_MESSAGES", "django.po")
+        )
+        old_cwd = os.getcwd()
+        os.chdir(td)
+        try:
+            dist = Distribution(attrs={"name": "demo"})
+            load_pyproject_config(dist, {})
+        finally:
+            os.chdir(old_cwd)
+
+        assert dist.gettext_source_dir == "locale"
+
+
+def test_find_source_files_auto_detects_locale():
+    with TemporaryDirectory() as td:
+        write_file(os.path.join(td, "locale", "django.pot"))
+        write_file(
+            os.path.join(td, "locale", "de", "LC_MESSAGES", "django.po")
+        )
+
+        found = find_source_files(td)
+
+        assert sorted(os.path.relpath(path, td) for path in found) == [
+            os.path.join("locale", "de", "LC_MESSAGES", "django.po"),
+            os.path.join("locale", "django.pot"),
+        ]


### PR DESCRIPTION
Detect both `po/<code>.po` and `locale/<code>/LC_MESSAGES/<domain>.po` and adjust the compilation pipeline to preserve the domain from the filename.

I didn't want to stack this on top of https://github.com/breezy-team/setuptools-gettext/pull/191 for easier review, but it will probably end up with conflicts, which I will resolve after one of the PRs is merged.