### PR TITLE
Add support for package-based installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ standard gettext layout with ``locale/*/LC_MESSAGES/*.po`` files. If ``po`` is
 absent and a top-level ``locale`` directory contains standard gettext catalogs,
 that directory is used automatically.
 
-The .mo files are installed adjacent to your package as package data in a subdirectory called ``locale``.
+By default, the ``install_mo`` command installs compiled catalogs under
+``share/locale`` to preserve compatibility with earlier releases. Django apps
+and other packages that load catalogs from package data can opt into package
+installation with ``install_layout = "package"``.
 
 You can override these settings in ``pyproject.toml``:
 
@@ -29,6 +32,8 @@ source_dir = "po"
 build_dir = "breezy/locale"
 # compiler to use: "auto", "msgfmt", or "translate-toolkit"
 compiler = "auto"
+# install compiled catalogs below share/locale or inside a package
+install_layout = "share"
 ```
 
 For standard gettext layouts, point both directories at the locale tree:
@@ -44,6 +49,20 @@ Flat ``po/de.po`` files compile to
 ``locale/de/LC_MESSAGES/django.po`` files compile to
 ``<build_dir>/de/LC_MESSAGES/django.mo`` by default. Passing
 ``--output-base`` overrides the output name for both layouts.
+
+For Django apps, keep the ``locale`` directory inside the app package and use
+the package install layout:
+
+```toml
+[tool.setuptools-gettext]
+source_dir = "myapp/locale"
+build_dir = "myapp/locale"
+install_layout = "package"
+```
+
+With this configuration, ``myapp/locale/de/LC_MESSAGES/django.po`` compiles to
+``myapp/locale/de/LC_MESSAGES/django.mo`` and is included as package data when
+building the package.
 
 ## Compilation tool
 

--- a/example/pyproject.toml
+++ b/example/pyproject.toml
@@ -14,3 +14,4 @@ source_dir = "po"
 # Set the build directory, to make it easier to find the compiled catalogs
 # in the source tree.
 build_dir = "hallowereld/locale"
+install_layout = "package"

--- a/setuptools_gettext/__init__.py
+++ b/setuptools_gettext/__init__.py
@@ -38,6 +38,13 @@ from .catalog import (
     mo_basename,
     parse_lang,
 )
+from .install_layout import (
+    DEFAULT_INSTALL_LAYOUT,
+    add_package_data_for_build_dir,
+    normalize_install_layout,
+    package_install_dir,
+    package_locale_info,
+)
 
 __version__ = (0, 1, 18)
 DEFAULT_SOURCE_DIR = "po"
@@ -80,6 +87,25 @@ def _resolve_source_dir(dist: Distribution) -> str:
         source_dir = _detect_default_source_dir()
         dist.gettext_source_dir = source_dir  # type: ignore
     return source_dir
+
+
+def _insert_sub_command(command_class, name, predicate, before=None) -> None:
+    sub_commands = [
+        sub_command
+        for sub_command in command_class.sub_commands
+        if sub_command[0] != name
+    ]
+    entry = (name, predicate)
+    if before is not None:
+        for index, sub_command in enumerate(sub_commands):
+            if sub_command[0] == before:
+                sub_commands.insert(index, entry)
+                break
+        else:
+            sub_commands.append(entry)
+    else:
+        sub_commands.append(entry)
+    command_class.sub_commands = sub_commands
 
 
 # Imported from distutils.util in Python 3.11:
@@ -153,6 +179,15 @@ class build_mo(Command):
                 getattr(self.distribution, "gettext_build_dir", None)
                 or DEFAULT_BUILD_DIR
             )
+        if (
+            getattr(
+                self.distribution,
+                "gettext_install_layout",
+                DEFAULT_INSTALL_LAYOUT,
+            )
+            == "package"
+        ):
+            add_package_data_for_build_dir(self.distribution, self.build_dir)
         if self.msgfmt is None and self.translate_toolkit is None:
             compiler = getattr(
                 self.distribution, "gettext_compiler", DEFAULT_COMPILER
@@ -330,16 +365,30 @@ class install_mo(Command):
         self.data_files: List[str] = []
         self.build_dir = None
         self.install_dir = None
+        self.install_layout = DEFAULT_INSTALL_LAYOUT
         self.outfiles: List[str] = []
+        self.package_locale: Optional[Tuple[str, str, str]] = None
         self.root = None
         self.force = 0
 
     def finalize_options(self) -> None:
         if self.build_dir is None:
-            self.build_dir = self.distribution.gettext_build_dir  # type: ignore
+            self.build_dir = self.distribution.gettext_build_dir  # type: ignore[attr-defined]
+        self.install_layout = getattr(
+            self.distribution,
+            "gettext_install_layout",
+            DEFAULT_INSTALL_LAYOUT,
+        )
+        if self.install_layout == "package":
+            install_dir_option = "install_lib"
+            self.package_locale = package_locale_info(
+                self.distribution, self.build_dir
+            )
+        else:
+            install_dir_option = "install_data"
         self.set_undefined_options(
             "install",
-            ("install_data", "install_dir"),
+            (install_dir_option, "install_dir"),
             ("root", "root"),
             ("force", "force"),
         )
@@ -349,10 +398,17 @@ class install_mo(Command):
         self.mkpath(self.install_dir)
         assert self.build_dir is not None
         for filepath in gather_built_files(self.build_dir):
-            langfile = filepath[len(self.build_dir.rstrip("/") + "/") :]
-            install_dir = os.path.dirname(
-                os.path.join("share/locale", langfile)
-            )
+            langfile = os.path.relpath(filepath, self.build_dir)
+            if self.install_layout == "package":
+                assert self.package_locale is not None
+                package, _package_dir, relative_build_dir = self.package_locale
+                install_dir = package_install_dir(
+                    package, relative_build_dir, langfile
+                )
+            else:
+                install_dir = os.path.dirname(
+                    os.path.join("share/locale", langfile)
+                )
 
             # it's a tuple with path to install to and a list of files
             dir = convert_path(install_dir)
@@ -446,18 +502,20 @@ def _load_pyproject_toml(path: str = "pyproject.toml") -> dict:
 
 
 def pyprojecttoml_config(dist: Distribution) -> None:
-    build = dist.get_command_class("build")
-    build.sub_commands.append(("build_mo", has_gettext))
-    clean = dist.get_command_class("clean")
-    clean.sub_commands.append(("clean_mo", has_gettext))
-    install = dist.get_command_class("install")
-    install.sub_commands.append(("install_mo", has_gettext))
-
     load_pyproject_config(dist, _load_pyproject_toml())
+
+    build = dist.get_command_class("build")
+    _insert_sub_command(build, "build_mo", has_gettext, before="build_py")
+    clean = dist.get_command_class("clean")
+    _insert_sub_command(clean, "clean_mo", has_gettext)
+    install = dist.get_command_class("install")
+    _insert_sub_command(install, "install_mo", has_gettext)
 
 
 def load_pyproject_config(dist: Distribution, cfg) -> None:
-    dist.gettext_source_dir_configured = bool(cfg.get("source_dir"))  # type: ignore
+    dist.gettext_source_dir_configured = (  # type: ignore
+        bool(cfg.get("source_dir"))
+    )
     dist.gettext_source_dir = (  # type: ignore
         cfg.get("source_dir") or _detect_default_source_dir()
     )
@@ -469,6 +527,9 @@ def load_pyproject_config(dist: Distribution, cfg) -> None:
     )
     dist.gettext_compiler = _normalize_compiler(  # type: ignore
         cfg.get("compiler", DEFAULT_COMPILER)
+    )
+    dist.gettext_install_layout = normalize_install_layout(  # type: ignore
+        cfg.get("install_layout", DEFAULT_INSTALL_LAYOUT)
     )
 
 

--- a/setuptools_gettext/install_layout.py
+++ b/setuptools_gettext/install_layout.py
@@ -1,0 +1,155 @@
+#
+# Copyright (C) 2026 Michal Cihar <michal@weblate.org>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston,
+# MA 02110-1301 USA
+
+"""Install layout helpers for compiled gettext catalogs."""
+
+import os
+from typing import List, Tuple
+
+from setuptools.dist import Distribution
+from setuptools.errors import OptionError
+
+from .catalog import LC_MESSAGES
+
+DEFAULT_INSTALL_LAYOUT = "share"
+VALID_INSTALL_LAYOUTS = ("share", "package")
+
+
+def normalize_install_layout(install_layout) -> str:
+    if install_layout is None:
+        return DEFAULT_INSTALL_LAYOUT
+    if not isinstance(install_layout, str):
+        raise ValueError(
+            "Unsupported setuptools-gettext install_layout "
+            f"{install_layout!r}; expected one of: "
+            f"{', '.join(VALID_INSTALL_LAYOUTS)}"
+        )
+    install_layout = install_layout.strip().lower()
+    if install_layout not in VALID_INSTALL_LAYOUTS:
+        raise ValueError(
+            "Unsupported setuptools-gettext install_layout "
+            f"{install_layout!r}; expected one of: "
+            f"{', '.join(VALID_INSTALL_LAYOUTS)}"
+        )
+    return install_layout
+
+
+def package_locale_info(
+    dist: Distribution, build_dir: str
+) -> Tuple[str, str, str]:
+    matches = []
+    for package in getattr(dist, "packages", None) or []:
+        package_dir = _get_package_dir(dist, package)
+        if _is_inside_path(build_dir, package_dir):
+            relative = os.path.relpath(
+                os.path.abspath(build_dir), os.path.abspath(package_dir)
+            )
+            matches.append(
+                (
+                    len(os.path.abspath(package_dir)),
+                    package,
+                    package_dir,
+                    "" if relative == os.curdir else relative,
+                )
+            )
+
+    if not matches:
+        raise OptionError(
+            "setuptools-gettext install_layout='package' requires "
+            "build_dir to be inside a configured package"
+        )
+
+    _length, package, package_dir, relative = max(matches)
+    return package, package_dir, relative
+
+
+def add_package_data_for_build_dir(dist: Distribution, build_dir: str) -> None:
+    package, _package_dir, relative_build_dir = package_locale_info(
+        dist, build_dir
+    )
+    pattern = _package_data_pattern(relative_build_dir)
+
+    package_data = getattr(dist, "package_data", None) or {}
+    patterns = list(package_data.get(package, []))
+    if pattern not in patterns:
+        patterns.append(pattern)
+    package_data[package] = patterns
+    dist.package_data = package_data
+
+
+def package_install_dir(
+    package: str, relative_build_dir: str, langfile: str
+) -> str:
+    parts = package.split(".")
+    if relative_build_dir:
+        parts.append(relative_build_dir)
+    parts.append(langfile)
+    return os.path.dirname(os.path.join(*parts))
+
+
+def _get_package_dir(dist: Distribution, package: str) -> str:
+    path = package.split(".")
+    package_dir = getattr(dist, "package_dir", None) or {}
+    if not package_dir:
+        result = os.path.join(*path) if path else ""
+    else:
+        tail: List[str] = []
+        while path:
+            package_name = ".".join(path)
+            if package_name in package_dir:
+                tail.insert(0, package_dir[package_name])
+                result = os.path.join(*tail)
+                break
+            tail.insert(0, path[-1])
+            del path[-1]
+        else:
+            default_dir = package_dir.get("")
+            if default_dir is not None:
+                tail.insert(0, default_dir)
+            result = os.path.join(*tail) if tail else ""
+
+    src_root = getattr(dist, "src_root", None)
+    if src_root is not None:
+        return os.path.join(src_root, result)
+    return result
+
+
+def _is_inside_path(path: str, parent: str) -> bool:
+    path = os.path.normcase(os.path.abspath(path))
+    parent = os.path.normcase(os.path.abspath(parent))
+    try:
+        relative = os.path.relpath(path, parent)
+    except ValueError:
+        return False
+    return relative == os.curdir or (
+        relative != os.pardir and not relative.startswith(os.pardir + os.sep)
+    )
+
+
+def _package_data_pattern(relative_build_dir: str) -> str:
+    relative_build_dir = relative_build_dir.replace(os.sep, "/")
+    return "/".join(
+        part
+        for part in (
+            relative_build_dir,
+            "*",
+            LC_MESSAGES,
+            "*.mo",
+        )
+        if part
+    )

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -61,6 +61,7 @@ def test_load_pyproject_config_default_compiler():
     load_pyproject_config(dist, {})
 
     assert getattr(dist, "gettext_compiler") == "auto"
+    assert getattr(dist, "gettext_install_layout") == "share"
 
 
 @pytest.mark.parametrize("compiler", ["auto", "msgfmt", "translate-toolkit"])
@@ -77,6 +78,22 @@ def test_load_pyproject_config_rejects_invalid_compiler():
 
     with pytest.raises(ValueError, match="Unsupported setuptools-gettext"):
         load_pyproject_config(dist, {"compiler": "invalid"})
+
+
+@pytest.mark.parametrize("install_layout", ["share", "package"])
+def test_load_pyproject_config_install_layout(install_layout):
+    dist = Distribution()
+
+    load_pyproject_config(dist, {"install_layout": install_layout})
+
+    assert getattr(dist, "gettext_install_layout") == install_layout
+
+
+def test_load_pyproject_config_rejects_invalid_install_layout():
+    dist = Distribution()
+
+    with pytest.raises(ValueError, match="Unsupported setuptools-gettext"):
+        load_pyproject_config(dist, {"install_layout": "invalid"})
 
 
 def test_build_mo_uses_msgfmt_compiler_from_config():

--- a/tests/test_setuptools_gettext.py
+++ b/tests/test_setuptools_gettext.py
@@ -1,18 +1,22 @@
 import os
 from tempfile import TemporaryDirectory
+from typing import NoReturn
 
 import pytest
 from setuptools import Distribution
 from setuptools.errors import OptionError
 
 import setuptools_gettext
+import setuptools_gettext.install_layout
 from setuptools_gettext import (
     build_mo,
     discover_catalogs,
     find_source_files,
     gather_built_files,
+    install_mo,
     load_pyproject_config,
     parse_lang,
+    pyprojecttoml_config,
 )
 from setuptools_gettext.catalog import lang_from_dir
 
@@ -190,6 +194,213 @@ def test_build_mixed_layouts_without_output_collision(monkeypatch):
                 os.path.join(build_dir, "de", "LC_MESSAGES", "django.mo"),
             ),
         }
+
+
+def test_package_layout_build_py_copies_generated_mo(monkeypatch):
+    with TemporaryDirectory() as td:
+        app_dir = os.path.join(td, "myapp")
+        write_file(os.path.join(app_dir, "__init__.py"))
+        locale = os.path.join(app_dir, "locale")
+        po = os.path.join(locale, "de", "LC_MESSAGES", "django.po")
+        write_file(po)
+        dist = Distribution(
+            attrs={
+                "name": "demo",
+                "packages": ["myapp"],
+                "package_dir": {"myapp": app_dir},
+            }
+        )
+        dist.script_name = "setup.py"
+        load_pyproject_config(
+            dist,
+            {
+                "source_dir": locale,
+                "build_dir": locale,
+                "install_layout": "package",
+            },
+        )
+        old_cwd = os.getcwd()
+        os.chdir(td)
+        try:
+            cmd = build_mo(dist)
+            cmd.initialize_options()
+            cmd.finalize_options()
+            compiled = run_build(cmd, monkeypatch)
+
+            build_py = dist.get_command_obj("build_py")
+            build_py.ensure_finalized()
+            build_py.build_lib = os.path.join(td, "build")
+            build_py.run()
+        finally:
+            os.chdir(old_cwd)
+
+        mo = os.path.join(locale, "de", "LC_MESSAGES", "django.mo")
+        assert compiled == [(po, mo)]
+        assert os.path.exists(
+            os.path.join(
+                td,
+                "build",
+                "myapp",
+                "locale",
+                "de",
+                "LC_MESSAGES",
+                "django.mo",
+            )
+        )
+
+
+def test_install_mo_share_layout_keeps_legacy_destination():
+    with TemporaryDirectory() as td:
+        build_dir = os.path.join(td, "build")
+        mo = os.path.join(build_dir, "de", "LC_MESSAGES", "django.mo")
+        write_file(mo)
+        install_dir = os.path.join(td, "install")
+        dist = Distribution(attrs={"name": "demo"})
+        load_pyproject_config(dist, {"build_dir": build_dir})
+        cmd = install_mo(dist)
+        cmd.initialize_options()
+        cmd.install_dir = install_dir
+        cmd.finalize_options()
+
+        cmd.run()
+
+        installed = os.path.join(
+            install_dir,
+            "share",
+            "locale",
+            "de",
+            "LC_MESSAGES",
+            "django.mo",
+        )
+        assert cmd.get_outputs() == [installed]
+        assert os.path.exists(installed)
+
+
+def test_install_mo_package_layout_installs_inside_package():
+    with TemporaryDirectory() as td:
+        app_dir = os.path.join(td, "myapp")
+        write_file(os.path.join(app_dir, "__init__.py"))
+        build_dir = os.path.join(app_dir, "locale")
+        mo = os.path.join(build_dir, "de", "LC_MESSAGES", "django.mo")
+        write_file(mo)
+        install_dir = os.path.join(td, "install")
+        dist = Distribution(
+            attrs={
+                "name": "demo",
+                "packages": ["myapp"],
+                "package_dir": {"myapp": app_dir},
+            }
+        )
+        load_pyproject_config(
+            dist, {"build_dir": build_dir, "install_layout": "package"}
+        )
+        cmd = install_mo(dist)
+        cmd.initialize_options()
+        cmd.install_dir = install_dir
+        cmd.finalize_options()
+
+        cmd.run()
+
+        installed = os.path.join(
+            install_dir,
+            "myapp",
+            "locale",
+            "de",
+            "LC_MESSAGES",
+            "django.mo",
+        )
+        assert cmd.get_outputs() == [installed]
+        assert os.path.exists(installed)
+
+
+def test_install_mo_package_layout_installs_src_layout_package():
+    with TemporaryDirectory() as td:
+        app_dir = os.path.join(td, "src", "myapp")
+        write_file(os.path.join(app_dir, "__init__.py"))
+        build_dir = os.path.join(app_dir, "locale")
+        write_file(os.path.join(build_dir, "de", "LC_MESSAGES", "django.mo"))
+        install_dir = os.path.join(td, "install")
+        dist = Distribution(
+            attrs={
+                "name": "demo",
+                "packages": ["myapp"],
+                "package_dir": {"": os.path.join(td, "src")},
+            }
+        )
+        load_pyproject_config(
+            dist, {"build_dir": build_dir, "install_layout": "package"}
+        )
+        cmd = install_mo(dist)
+        cmd.initialize_options()
+        cmd.install_dir = install_dir
+        cmd.finalize_options()
+
+        cmd.run()
+
+        assert cmd.get_outputs() == [
+            os.path.join(
+                install_dir,
+                "myapp",
+                "locale",
+                "de",
+                "LC_MESSAGES",
+                "django.mo",
+            )
+        ]
+
+
+def test_package_layout_rejects_build_dir_outside_packages():
+    with TemporaryDirectory() as td:
+        build_dir = os.path.join(td, "locale")
+        write_file(os.path.join(build_dir, "de", "LC_MESSAGES", "django.mo"))
+        dist = Distribution(attrs={"name": "demo", "packages": ["myapp"]})
+        load_pyproject_config(
+            dist, {"build_dir": build_dir, "install_layout": "package"}
+        )
+        cmd = install_mo(dist)
+        cmd.initialize_options()
+        cmd.install_dir = os.path.join(td, "install")
+
+        with pytest.raises(OptionError, match="inside a configured package"):
+            cmd.finalize_options()
+
+
+def test_package_layout_rejects_build_dir_on_different_mount(monkeypatch):
+    with TemporaryDirectory() as td:
+        build_dir = os.path.join(td, "locale")
+        write_file(os.path.join(build_dir, "de", "LC_MESSAGES", "django.mo"))
+        dist = Distribution(attrs={"name": "demo", "packages": ["myapp"]})
+        load_pyproject_config(
+            dist, {"build_dir": build_dir, "install_layout": "package"}
+        )
+
+        def raise_value_error(_path, _parent) -> NoReturn:
+            raise ValueError("path is on mount 'c:', start on mount 'd:'")
+
+        monkeypatch.setattr(
+            setuptools_gettext.install_layout.os.path,
+            "relpath",
+            raise_value_error,
+        )
+        cmd = install_mo(dist)
+        cmd.initialize_options()
+        cmd.install_dir = os.path.join(td, "install")
+
+        with pytest.raises(OptionError, match="inside a configured package"):
+            cmd.finalize_options()
+
+
+def test_pyproject_config_registers_build_mo_before_build_py():
+    dist = Distribution()
+
+    pyprojecttoml_config(dist)
+
+    sub_commands = [
+        sub_command[0]
+        for sub_command in dist.get_command_class("build").sub_commands
+    ]
+    assert sub_commands.count("build_mo") == 1
+    assert sub_commands.index("build_mo") < sub_commands.index("build_py")
 
 
 def test_duplicate_output_paths_are_rejected():


### PR DESCRIPTION
This is what Django apps use - the locales are shipped as package data and not in the standard system locale paths.